### PR TITLE
Add support for custom catalog name (and resources tarball names as well)

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,6 @@
 
 The `catalog-cd` is the tool(kit) to manage a catalog repository as well
 as helping Tekton resources (`Task`, `Pipeline`, …) authors management in
-external repostiories.  
+external repostiories.
 
 *This is a work in progress and **very early stages***.

--- a/internal/catalog/catalog.go
+++ b/internal/catalog/catalog.go
@@ -38,7 +38,7 @@ func FetchFromExternals(e config.External, client *api.RESTClient) (Catalog, err
 		}
 
 		for version := range m {
-			resourcesDownloaldURI := fmt.Sprintf("%s/releases/download/%s/%s", r.URL, version, "resources.tar.gz")
+			resourcesDownloaldURI := fmt.Sprintf("%s/releases/download/%s/%s", r.URL, version, r.ResourcesTarballName)
 			if strings.HasPrefix(version, "v") {
 				version = strings.TrimPrefix(version, "v")
 			}

--- a/internal/contract/contract.go
+++ b/internal/contract/contract.go
@@ -16,7 +16,9 @@ const (
 	// Version current contract version.
 	Version = "v1"
 	// Filename default contract file name.
-	Filename = ".catalog.yaml"
+	Filename = "catalog.yaml"
+	// Resources default file name
+	ResourcesName = "resources.tar.gz"
 	// SignatureExtension
 	SignatureExtension = "sig"
 )
@@ -90,7 +92,7 @@ func (c *Contract) SaveAs(file string) error {
 	if err != nil {
 		return err
 	}
-	return os.WriteFile(file, payload, 0644)
+	return os.WriteFile(file, payload, 0o644)
 }
 
 // NewContractEmpty instantiates a new Contract{} with empty attributes.

--- a/internal/contract/contract_test.go
+++ b/internal/contract/contract_test.go
@@ -11,7 +11,7 @@ func TestNewContractEmpty(t *testing.T) {
 	t.Skip("Skipping, need to be rewritten")
 	g := o.NewWithT(t)
 
-	testDir := "../../test/resources"
+	testDir := "../../testdata/resources"
 
 	c := NewContractEmpty()
 

--- a/internal/fetcher/config/config.go
+++ b/internal/fetcher/config/config.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/openshift-pipelines/catalog-cd/internal/contract"
 	"sigs.k8s.io/yaml"
 )
 
@@ -19,18 +20,35 @@ type Repository struct {
 	Name string
 	URL  string
 	// Type defines the type to fetch (Task, Pipeline, …)
-	Types          []string
-	IgnoreVersions []string `json:"ignore-versions"`
+	Types                []string
+	IgnoreVersions       []string `json:"ignore-versions"`
+	CatalogName          string   `json:"catalog-name"`
+	ResourcesTarballName string   `json:"resources-tarball-name"`
+}
+
+// setDefaults sets the default values for the configuration
+func setDefaults(e External) External {
+	for i, r := range e.Repositories {
+		if r.CatalogName == "" {
+			r.CatalogName = contract.Filename
+		}
+		if r.ResourcesTarballName == "" {
+			r.ResourcesTarballName = contract.ResourcesName
+		}
+		e.Repositories[i] = r
+	}
+	return e
 }
 
 func LoadExternal(filename string) (External, error) {
 	var c External
 	data, err := os.ReadFile(filename)
 	if err != nil {
-		return c, fmt.Errorf("Could not load external configuration from %s: %w", filename, err)
+		return External{}, fmt.Errorf("Could not load external configuration from %s: %w", filename, err)
 	}
 	if err := yaml.Unmarshal(data, &c); err != nil {
-		return c, fmt.Errorf("Could not load external configuration from %s: %w", filename, err)
+		return External{}, fmt.Errorf("Could not load external configuration from %s: %w", filename, err)
 	}
+	c = setDefaults(c)
 	return c, nil
 }

--- a/internal/fetcher/config/testdata/external.pipeline.valid.yaml
+++ b/internal/fetcher/config/testdata/external.pipeline.valid.yaml
@@ -2,3 +2,5 @@ repositories:
 - name: sbr-golang
   url: https://github.com/shortbrain/golang-tasks
   types: [ pipelines ]
+  catalog-name: catalog.foo.yaml
+  resources-tarball-name: resources.foo.tar.gz

--- a/internal/fetcher/fetcher.go
+++ b/internal/fetcher/fetcher.go
@@ -29,7 +29,8 @@ func FetchContractsFromRepository(r config.Repository, client *api.RESTClient) (
 		var contractAsset Asset
 		contractFound := false
 		for _, a := range v.Assets {
-			if a.Name == "catalog.yaml" || a.Name == "catalog.yml" {
+			// catalog.yml is there for backward-compatibility
+			if a.Name == r.CatalogName || a.Name == "catalog.yml" {
 				contractFound = true
 				contractAsset = a
 				break

--- a/testdata/resources/catalog.yaml
+++ b/testdata/resources/catalog.yaml
@@ -1,0 +1,17 @@
+version: v1
+catalog:
+  repository:
+    description: ""
+  attestation:
+    publickey: ""
+  resources:
+    tasks:
+      - name: task
+        version: 0.0.1
+        filename: ../../test/resources/task.yaml
+        checksum: f2d507741e983223beb94b5411264004e8d2cbbf0326a716c8313002e505e706
+        signature: ""
+    pipelines: []
+  probe:
+    tasks: []
+    pipelines: []


### PR DESCRIPTION
The path of `catalog.yaml` and `resources.tar.gz` on releases shouldn't be hard-coded in the tooling (`catalog-cd`) but be _defaults_.

Assuming upstream supports the same mechanism, we may want to release a given set of task for both upstream and downstream at the same time (same version). For this, we would need to have multiple `catalog.yaml` per release and a way to configure, on the pulling side, which _files_ to look at.

This is linked to [SRVKP-3991](https://issues.redhat.com/browse/SRVKP-3991).